### PR TITLE
Refactor unit tests for improved DbContext management

### DIFF
--- a/SchoolMedicalWpf.UnitTest/SchoolMedicalWpf.UnitTest.csproj
+++ b/SchoolMedicalWpf.UnitTest/SchoolMedicalWpf.UnitTest.csproj
@@ -13,7 +13,6 @@
 		<PackageReference Include="coverlet.collector" Version="6.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.5.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
 	</ItemGroup>


### PR DESCRIPTION
Removed Moq package reference and added support for in-memory database testing with new package references. Updated `UserServiceTest` to utilize a DbContext factory for better lifecycle management and test isolation. Adjusted test methods to ensure fresh DbContext instances for each test.